### PR TITLE
Replace Ruff lint checker gh action with autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,18 @@
+name: autofix.ci  # needed to securely identify the workflow
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # TODO: add all code-fixing here.
+
+      - uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # TODO: add all code-fixing here.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      # Fix lint errors
+      - run: uvx ruff check --fix-only .
+      # Format code
+      - run: uvx ruff format .
 
       - uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           enable-cache: true
       # Fix lint errors
-      - run: uvx ruff check --fix-only .
+      - run: uvx ruff check --fix .
       # Format code
       - run: uvx ruff format .
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,8 +1,0 @@
-name: Ruff
-on: [push, pull_request]
-jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1

--- a/src/jreadability/jreadability.py
+++ b/src/jreadability/jreadability.py
@@ -22,6 +22,8 @@ def compute_readability(text: str, tagger: Optional[Tagger] = None) -> float:
         float: A float representing the readability score of the text.
     """
 
+    my_useless_var = 10
+
     if tagger is None:
         # initialize mecab parser
         tagger = Tagger()

--- a/src/jreadability/jreadability.py
+++ b/src/jreadability/jreadability.py
@@ -85,13 +85,6 @@ def compute_readability(text: str, tagger: Optional[Tagger] = None) -> float:
     percentage_of_verbs = 100.0 * num_verbs / len(doc)
     percentage_of_particles = 100.0 * num_particles / len(doc)
 
-    readability_score = (
-        mean_length_of_sentence * -0.056
-        + percentage_of_kango * -0.126
-        + percentage_of_wago * -0.042
-        + percentage_of_verbs * -0.145
-        + percentage_of_particles * -0.044
-        + 11.724
-    )
+    readability_score = ( mean_length_of_sentence * -0.056 + percentage_of_kango * -0.126 + percentage_of_wago * -0.042 + percentage_of_verbs * -0.145 + percentage_of_particles * -0.044 + 11.724)
 
     return readability_score

--- a/src/jreadability/jreadability.py
+++ b/src/jreadability/jreadability.py
@@ -85,6 +85,13 @@ def compute_readability(text: str, tagger: Optional[Tagger] = None) -> float:
     percentage_of_verbs = 100.0 * num_verbs / len(doc)
     percentage_of_particles = 100.0 * num_particles / len(doc)
 
-    readability_score = ( mean_length_of_sentence * -0.056 + percentage_of_kango * -0.126 + percentage_of_wago * -0.042 + percentage_of_verbs * -0.145 + percentage_of_particles * -0.044 + 11.724)
+    readability_score = (
+        mean_length_of_sentence * -0.056
+        + percentage_of_kango * -0.126
+        + percentage_of_wago * -0.042
+        + percentage_of_verbs * -0.145
+        + percentage_of_particles * -0.044
+        + 11.724
+    )
 
     return readability_score

--- a/src/jreadability/jreadability.py
+++ b/src/jreadability/jreadability.py
@@ -22,8 +22,6 @@ def compute_readability(text: str, tagger: Optional[Tagger] = None) -> float:
         float: A float representing the readability score of the text.
     """
 
-    my_useless_var = 10
-
     if tagger is None:
         # initialize mecab parser
         tagger = Tagger()

--- a/src/jreadability/jreadability.py
+++ b/src/jreadability/jreadability.py
@@ -8,6 +8,7 @@ There are no other public functions, classes or variables.
 from fugashi import Tagger
 from typing import List, Optional
 from fugashi.fugashi import UnidicNode
+import os
 
 
 def compute_readability(text: str, tagger: Optional[Tagger] = None) -> float:

--- a/src/jreadability/jreadability.py
+++ b/src/jreadability/jreadability.py
@@ -8,7 +8,6 @@ There are no other public functions, classes or variables.
 from fugashi import Tagger
 from typing import List, Optional
 from fugashi.fugashi import UnidicNode
-import os
 
 
 def compute_readability(text: str, tagger: Optional[Tagger] = None) -> float:


### PR DESCRIPTION
This PR attempts to replace the Ruff lint checker github action with the [autofix.ci](https://autofix.ci/) github action that can automatically fix certain linting and formatting errors.