### PR TITLE
add codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,13 @@ jobs:
         - name: Install dependencies
           run: |
             python -m pip install --upgrade pip
-            pip install pytest
+            pip install pytest pytest-cov
             pip install .
         - name: Test with pytest
           run: |
-            pytest
+            pytest --cov --cov-branch --cov-report=xml
+        - name: Upload coverage reports to Codecov
+          uses: codecov/codecov-action@v5
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            slug: joshdavham/jreadability


### PR DESCRIPTION
This PR attempts to add the [codecov](https://about.codecov.io/) CI tool for reporting on this repo's code coverage from the tests.