### PR TITLE
Fix paragraphs and full width spaces

### DIFF
--- a/src/jreadability/jreadability.py
+++ b/src/jreadability/jreadability.py
@@ -6,8 +6,7 @@ There are no other public functions, classes or variables.
 """
 
 from fugashi import Tagger
-from typing import List, Optional
-from fugashi.fugashi import UnidicNode
+from typing import Optional
 import re
 
 

--- a/src/jreadability/jreadability.py
+++ b/src/jreadability/jreadability.py
@@ -27,24 +27,22 @@ def compute_readability(text: str, tagger: Optional[Tagger] = None) -> float:
 
     doc = tagger(text)
 
-    #Remove full-width spaces, standard spaces, and empty tokens
+    # Remove full-width spaces, standard spaces, and empty tokens
     doc = [t for t in doc if t.surface.strip() and t.surface not in ("　")]
-
 
     def split_japanese_sentences(text, tagger):
         """
         Helper function that breaks the parsed text into lists of sentences.
         """
         text = text.replace("\r\n", "\n").replace("\r", "\n")
-        paragraphs = re.split(r'\n\s*\n+', text)
+        paragraphs = re.split(r"\n\s*\n+", text)
         sentences = []
 
         for paragraph in paragraphs:
-
             current_sentence = []
             doc = tagger(paragraph)
             doc = [t for t in doc if t.surface.strip() and t.surface not in ("　")]
-            
+
             for token in doc:
                 current_sentence.append(token)
 

--- a/src/jreadability/jreadability.py
+++ b/src/jreadability/jreadability.py
@@ -8,6 +8,7 @@ There are no other public functions, classes or variables.
 from fugashi import Tagger
 from typing import List, Optional
 from fugashi.fugashi import UnidicNode
+import re
 
 
 def compute_readability(text: str, tagger: Optional[Tagger] = None) -> float:
@@ -21,35 +22,45 @@ def compute_readability(text: str, tagger: Optional[Tagger] = None) -> float:
     Returns:
         float: A float representing the readability score of the text.
     """
-
     if tagger is None:
         # initialize mecab parser
         tagger = Tagger()
 
     doc = tagger(text)
 
-    def split_japanese_sentences(doc: List[UnidicNode]) -> List[List[UnidicNode]]:
+    #Remove full-width spaces, standard spaces, and empty tokens
+    doc = [t for t in doc if t.surface.strip() and t.surface not in ("　")]
+
+
+    def split_japanese_sentences(text, tagger):
         """
         Helper function that breaks the parsed text into lists of sentences.
         """
-
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        paragraphs = re.split(r'\n\s*\n+', text)
         sentences = []
-        current_sentence = []
-        for token in doc:
-            current_sentence.append(token)
 
-            if token.surface in ("。", "？", "！", "．"):
+        for paragraph in paragraphs:
+
+            current_sentence = []
+            doc = tagger(paragraph)
+            doc = [t for t in doc if t.surface.strip() and t.surface not in ("　")]
+            
+            for token in doc:
+                current_sentence.append(token)
+
+                if token.surface in ("。", "？", "！", "．"):
+                    sentences.append(current_sentence)
+                    current_sentence = []
+
+            # if there's any leftover sentence that doesn't end with sentence-ending punctuation
+            if current_sentence:
                 sentences.append(current_sentence)
-                current_sentence = []
-
-        # if there's any leftover sentence that doesn't end with sentence-ending punctuation
-        if current_sentence:
-            sentences.append(current_sentence)
 
         return sentences
 
     # first, compute mean sentence length (in words, not characters)
-    sentences = split_japanese_sentences(doc)
+    sentences = split_japanese_sentences(text, tagger)
 
     sentence_lengths = []
     for sentence_doc in sentences:


### PR DESCRIPTION
This PR makes 2 changes which both bring the scores more in line with the official web implementation at https://jreadability.net/sys/en for certain types of content.

First, this better handles paragraphs/line breaks by splitting sentences whenever there are 2 or more line breaks. (for example, an html `<p>` tag will end a sentence, but a single `<br>` tag will not. )
In some types of text, its common to omit punctuation at the end of a sentence, which would cause sentences to appear much longer than they actually were, which in turn made the difficulty score much higher than it should be.

The second change is that full width spaces are stripped. (this has to be done both in the main doc, and within the split_japanese_sentences function)

This change makes the token count more closely match the token count on jreadability.net, and brings the score slightly closer to that score as well.

Here are the before and after results on the texts in test_jreadability.py
The line splitting does not effect any of these, though the full width space removal changes the first one.


upper_advanced_text - Original: 1.0664359061543713
upper_advanced_text - New: 1.0129233407648766
lower_advanced_text - Original: 2.3329023569023573
lower_advanced_text - New: 2.3329023569023573
upper_intermediate_text - Original: 3.0853157894736842
upper_intermediate_text - New: 3.0853157894736842
lower_intermediate_text - Original: 4.161580021715526
lower_intermediate_text - New: 4.161580021715526
upper_elementary_text - Original: 4.861306967984935
upper_elementary_text - New: 4.861306967984935
lower_elementary_text - Original: 5.613666666666667
lower_elementary_text - New: 5.613666666666667

Closes #16 